### PR TITLE
Automated Ethereum Network Identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,10 @@
 ##### Bugs fixed
 
 *Removed duplicate variable import
+
+### 1.3.2 (2020-01-31)
+
+##### Dynamic Network Selection
+
+*Transaction will be sent to the network specified in the RPC URL.
+*Etherscan link on the transaction success modal will be decided according to the network type.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inbloxme/keyless-transactions",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "This package enables usage of inblox handlename infrastructure as a keyless signing mechanism",
   "main": "src/index.js",
   "scripts": {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -3,6 +3,10 @@ module.exports = {
   AUTH_SERVICE_URL_DEV: 'https://dev-auth.inblox.me',
   AUTH_SERVICE_URL_TEST: 'https://test-auth.inblox.me',
   DEFAULT_GAS_LIMIT: 6000000,
+  MAINNET_ETHERSCAN_URL: 'https://etherscan.io/tx',
   ROPSTEN_ETHERSCAN_URL: 'https://ropsten.etherscan.io/tx',
+  RINKEBY_ETHERSCAN_URL: 'https://rinkeby.etherscan.io/tx',
+  GOERLI_ETHERSCAN_URL: 'https://goerli.etherscan.io/tx',
+  KOVAN_ETHERSCAN_URL: 'https://kovan.etherscan.io/tx',
   ETHERSCAN_LOGO_URL: 'https://etherscan.io/images/logo-ether.png',
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-return-assign */
 /* eslint-disable max-classes-per-file */
 /* eslint-disable class-methods-use-this */
 const ethers = require('ethers');
@@ -160,8 +161,12 @@ class Keyless {
         chainId: 3,
       };
 
+      let network;
+
+      await this.web3.eth.net.getNetworkType().then((e) => network = e);
+
       const pkey = Buffer.from(pKey, 'hex');
-      const tx = new Tx(rawTx, { chain: 'ropsten', hardfork: 'petersburg' });
+      const tx = new Tx(rawTx, { chain: network });
 
       tx.sign(pkey);
       const signedTx = `0x${tx.serialize().toString('hex')}`;

--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,14 @@ class Keyless {
       await this.web3.eth.net.getNetworkType().then((e) => network = e);
 
       const pkey = Buffer.from(pKey, 'hex');
-      const tx = new Tx(rawTx, { chain: network });
+
+      let tx;
+
+      if (network === 'main') {
+        tx = new Tx(rawTx, { chain: 'mainnet' });
+      } else {
+        tx = new Tx(rawTx, { chain: network });
+      }
 
       tx.sign(pkey);
       const signedTx = `0x${tx.serialize().toString('hex')}`;

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,6 @@ class Keyless {
         gas: this.web3.utils.numberToHex(gasLimit) || this.web3.utils.numberToHex(DEFAULT_GAS_LIMIT),
         data: data || '0x00',
         nonce: nonce || defaultNonce,
-        chainId: 3,
       };
 
       let network;

--- a/src/widget/index.js
+++ b/src/widget/index.js
@@ -19,7 +19,9 @@ import { signTransaction } from './pages/transactions/sign-transaction';
 import { signAndSendTransaction } from './pages/transactions/sign-and-send-transaction';
 
 const inbloxSDK = require('..');
-const { DEFAULT_GAS_LIMIT } = require('../config');
+const {
+  DEFAULT_GAS_LIMIT, ROPSTEN_ETHERSCAN_URL, RINKEBY_ETHERSCAN_URL, GOERLI_ETHERSCAN_URL, KOVAN_ETHERSCAN_URL, MAINNET_ETHERSCAN_URL,
+} = require('../config');
 
 const {
   USER_NOT_LOGGED_IN,
@@ -58,7 +60,6 @@ export class Widget {
     this.INITIALISED_EVENTS = [];
     this.eventEmitter = new events.EventEmitter();
   }
-
 
   getUserData() {
     if (this.isUserLoggedIn) {
@@ -285,7 +286,7 @@ export class Widget {
               signedData: signedTx.hash,
             },
           });
-        }  else {
+        } else {
           this.eventEmitter.emit(this.EVENTS.SIGN_TRANSACTION_FAILED, {
             status: true,
             eventName: this.EVENTS.SIGN_TRANSACTION_FAILED,
@@ -343,7 +344,24 @@ export class Widget {
 
   async setActiveTab(activeId, options = {}) {
     this.activeTabIdName = activeId;
-    this.activeTab = await getActiveTabModal(activeId, options);
+    let network;
+    let transactionUrl;
+
+    await this.inbloxKeyless.web3.eth.net.getNetworkType().then((e) => network = e);
+
+    if (network == 'main') {
+      transactionUrl = MAINNET_ETHERSCAN_URL;
+    } else if (network == 'ropsten') {
+      transactionUrl = ROPSTEN_ETHERSCAN_URL;
+    } else if (network == 'rinkeby') {
+      transactionUrl = RINKEBY_ETHERSCAN_URL;
+    } else if (network == 'kovan') {
+      transactionUrl = KOVAN_ETHERSCAN_URL;
+    } else if (network == 'goerli') {
+      transactionUrl = GOERLI_ETHERSCAN_URL;
+    }
+
+    this.activeTab = await getActiveTabModal(activeId, options, transactionUrl);
     generateModal(this);
   }
 }

--- a/src/widget/pages/message-handler.js
+++ b/src/widget/pages/message-handler.js
@@ -1,8 +1,6 @@
 import { inbloxWidgetIcon, closeIcon, inbloxMe } from '../assets/images';
 
-import { ROPSTEN_ETHERSCAN_URL } from '../../config';
-
-export function messageHandlerModal(message, transactionHash = null) {
+export function messageHandlerModal(message, transactionHash = null, transactionUrl) {
   return `
   <div class="widget-modal-content active" id="message-handler-modal">
     <div class="widget-modal-header">
@@ -21,9 +19,9 @@ export function messageHandlerModal(message, transactionHash = null) {
       ${
   transactionHash && transactionHash != undefined && transactionHash != ''
     ? `
-      <label class="ether-scan">
-      Check your transaction on <a href="${ROPSTEN_ETHERSCAN_URL}/${transactionHash}" target="_blank"><img src="https://etherscan.io/images/logo-ether.png" alt="ether-scan" class="ether-scan-logo"></a>
-      </label>
+    <label class="ether-scan">
+    Check your transaction on <a href="${transactionUrl}/${transactionHash}" target="_blank"><img src="https://etherscan.io/images/logo-ether.png" alt="ether-scan" class="ether-scan-logo"></a>
+    </label>
       `
     : ''
 }

--- a/src/widget/utils/ui-helper.js
+++ b/src/widget/utils/ui-helper.js
@@ -14,7 +14,7 @@ import { ModalLoader } from '../pages/loaders/modal-loader';
 
 const { KEYLESS_WIDGET_CLOSED } = require('../../constants/responses');
 
-export function getActiveTabModal(activeId, options) {
+export function getActiveTabModal(activeId, options, transactionUrl) {
   let activeTabModal = '';
 
   switch (activeId) {
@@ -23,27 +23,29 @@ export function getActiveTabModal(activeId, options) {
       break;
     case 'message-handler-modal':
       activeTabModal = messageHandlerModal(
-        options['message'],
-        options['transactionHash']
+        options.message,
+        options.transactionHash,
+        transactionUrl
       );
       break;
     case 'sign-transaction':
-      activeTabModal = signTransactionModal(options['currentUser']);
+      activeTabModal = signTransactionModal(options.currentUser);
       break;
     case 'sign-and-send-transaction':
-      activeTabModal = signAndSendTransactionModal(options['currentUser']);
+      activeTabModal = signAndSendTransactionModal(options.currentUser);
       break;
     case 'transaction-details-confirmation':
       activeTabModal = transactionDetailsConfirmation(
-        options['transactionData']
+        options.transactionData
       );
       break;
     case 'transaction-success':
-      activeTabModal = transactionSuccess(options['transactionHash']);
+      activeTabModal = transactionSuccess(options.transactionHash);
       break;
     default:
       activeTabModal = loginModal();
   }
+
   return activeTabModal;
 }
 
@@ -65,7 +67,7 @@ export async function generateModal(widgetInstance) {
   const inbloxKeylessWidget = document.getElementById('inbloxKeylessWidget');
 
   const style = await document.createElement('style');
-  
+
   style.innerHTML = exportCss();
   if (inbloxKeylessWidget) await inbloxKeylessWidget.appendChild(style);
 
@@ -94,16 +96,19 @@ export async function generateModal(widgetInstance) {
 
 export function showLoader() {
   const loader = document.getElementById('loader');
+
   loader.style.display = 'block';
 }
 
 export function hideLoader() {
   const loader = document.getElementById('loader');
+
   loader.style.display = 'none';
 }
 
 export async function showModalLoader() {
   let loaderWrapper = document.getElementById('keylessWidgetModalLoader');
+
   if (loaderWrapper == null) {
     loaderWrapper = document.createElement('div');
     loaderWrapper.id = 'keylessWidgetModalLoader';
@@ -111,17 +116,19 @@ export async function showModalLoader() {
   loaderWrapper.innerHTML = ModalLoader();
 
   let container = document.getElementsByTagName('body');
+
   if (!container) container = document.getElementsByTagName('html');
   if (!container) container = document.getElementsByTagName('div');
   await container[0].appendChild(loaderWrapper);
 
-  let widgetModalLoader = document.getElementById('keylessWidgetModalLoader');
+  const widgetModalLoader = document.getElementById('keylessWidgetModalLoader');
 
-  let style = await document.createElement('style');
+  const style = await document.createElement('style');
+
   style.innerHTML = exportCss();
   if (widgetModalLoader) await widgetModalLoader.appendChild(style);
 
-  //Prevent background scrolling when overlay appears
+  // Prevent background scrolling when overlay appears
   document.documentElement.style.overflow = 'hidden';
   document.body.scroll = 'no';
 
@@ -131,11 +138,10 @@ export async function showModalLoader() {
 }
 
 export function hideModalLoader() {
-  //Enable background scrolling when overlay removed
+  // Enable background scrolling when overlay removed
   document.documentElement.style.overflow = 'auto';
   document.body.scroll = 'yes';
   document.getElementById('keylessWidgetModalLoader').remove();
-  return;
 }
 
 export function closeModal(widgetInstance, initMethod = 'useractivity') {
@@ -157,6 +163,7 @@ export function closeModal(widgetInstance, initMethod = 'useractivity') {
 function initCloseEvents(widgetInstance) {
   const closeIcon = document.getElementById('close-icon');
   // When the user clicks on close icon (x), close the modal
+
   closeIcon.onclick = () => {
     closeModal(widgetInstance);
   };
@@ -164,6 +171,7 @@ function initCloseEvents(widgetInstance) {
   // When the user clicks anywhere outside of the modal, close it
   window.onclick = (event) => {
     const customModal = document.getElementById('inbloxKeylessWidget');
+
     if (customModal && event.target === customModal) {
       closeModal(widgetInstance);
     }


### PR DESCRIPTION
The Ethereum network type will be identified from the RPC URL passed into the constructor and it will be used for the Ether/ERC20 transfers or contract calls.

Also, the network on the Etherscan URL will be set in the success modal accordingly